### PR TITLE
Fix double quote token creation

### DIFF
--- a/minikabuk/src/executor/builtin_2.c
+++ b/minikabuk/src/executor/builtin_2.c
@@ -20,10 +20,10 @@ int	ft_cd(t_minishell *minishell)
 		ft_cd_back_start(minishell);
 		return (0);
 	}
-	result = ft_cd_util(tmp->next->token->value, cwd, new_path, minishell);
+    result = ft_cd_util(tmp->next->token->value, cwd, new_path, minishell);
     if (result != 0)
         return (1);
-	return (0);
+    return (0);
 }
 
 int	ft_export(t_minishell *minishell)

--- a/minikabuk/src/executor/exec_cmd.c
+++ b/minikabuk/src/executor/exec_cmd.c
@@ -1,4 +1,5 @@
 #include "executor.h"
+#include <sys/wait.h>
 
 void	execute_in_parent(char *cmd, t_minishell *minishell)
 {

--- a/minikabuk/src/executor/pipe.c
+++ b/minikabuk/src/executor/pipe.c
@@ -1,4 +1,5 @@
 #include "minishell.h"
+#include <sys/wait.h>
 
 static int execute_pipe_child(t_minishell *minishell)
 {

--- a/minikabuk/src/parser/parser.h
+++ b/minikabuk/src/parser/parser.h
@@ -35,5 +35,6 @@ void			parse_tokens(t_minishell *minishell);
 void			add_token_to_list(t_token_list **token_list, t_token *current_token);
 int				single_quotes(t_minishell *minishell, int *i, t_token **current_token);
 int 			double_quotes(t_minishell *minishell, int *i, t_token **current_token);
+int                     money_money(t_minishell *minishell, int *i, t_token **current_token);
 
 #endif

--- a/minikabuk/src/parser/quotes.c
+++ b/minikabuk/src/parser/quotes.c
@@ -1,84 +1,205 @@
 #include "minishell.h"
+#include <ctype.h>
 
-// int	money_money(t_minishell *minishell, int *i, t_token **current_token)
-// {
-// 
-// }
+static char    *get_env_value(t_minishell *minishell, char *key)
+{
+    t_env   *env;
+
+    env = minishell->envp;
+    while (env)
+    {
+        if (ft_strcmp(env->key, key) == 0)
+            return (env->value);
+        env = env->next;
+    }
+    return ("");
+}
+
+static long    eval_expr(char *expr)
+{
+    char    *p;
+    long    result;
+    long    value;
+    char    op;
+
+    p = expr;
+    result = strtol(p, &p, 10);
+    while (*p)
+    {
+        while (isspace(*p))
+            p++;
+        op = *p;
+        if (!op)
+            break ;
+        p++;
+        value = strtol(p, &p, 10);
+        if (op == '+')
+            result += value;
+        else if (op == '-')
+            result -= value;
+        else if (op == '*')
+            result *= value;
+        else if (op == '/')
+            result /= value;
+        else if (op == '%')
+            result %= value;
+    }
+    return (result);
+}
+
+int money_money(t_minishell *minishell, int *i, t_token **current_token)
+{
+    char    *tmp;
+    char    *value;
+    int     start;
+    long    num;
+
+    (*i)++; // skip $
+    if (minishell->input[*i] == '?')
+    {
+        tmp = ft_itoa(minishell->exit_status);
+        if (!tmp)
+            return (1);
+        *current_token = ft_calloc(sizeof(t_token), 1);
+        if (!*current_token)
+        {
+            free(tmp);
+            return (1);
+        }
+        (*current_token)->value = tmp;
+        (*current_token)->type = TOKEN_WORD;
+        add_token_to_list(&minishell->token_list, *current_token);
+        (*i)++;
+        return (0);
+    }
+    else if (minishell->input[*i] == '(' && minishell->input[*i + 1] == '(')
+    {
+        start = *i + 2;
+        *i += 2;
+        while (minishell->input[*i] && !(minishell->input[*i] == ')' && minishell->input[*i + 1] == ')'))
+            (*i)++;
+        if (!minishell->input[*i])
+            return (1);
+        tmp = ft_substr(minishell->input, start, *i - start);
+        if (!tmp)
+            return (1);
+        num = eval_expr(tmp);
+        free(tmp);
+        tmp = ft_itoa(num);
+        if (!tmp)
+            return (1);
+        *current_token = ft_calloc(sizeof(t_token), 1);
+        if (!*current_token)
+        {
+            free(tmp);
+            return (1);
+        }
+        (*current_token)->value = tmp;
+        (*current_token)->type = TOKEN_WORD;
+        add_token_to_list(&minishell->token_list, *current_token);
+        *i += 2;
+        return (0);
+    }
+    start = *i;
+    while (minishell->input[*i] && (ft_isalnum(minishell->input[*i]) || minishell->input[*i] == '_'))
+        (*i)++;
+    tmp = ft_substr(minishell->input, start, *i - start);
+    if (!tmp)
+        return (1);
+    value = ft_strdup(get_env_value(minishell, tmp));
+    free(tmp);
+    if (!value)
+        return (1);
+    *current_token = ft_calloc(sizeof(t_token), 1);
+    if (!*current_token)
+    {
+        free(value);
+        return (1);
+    }
+    (*current_token)->value = value;
+    (*current_token)->type = TOKEN_WORD;
+    add_token_to_list(&minishell->token_list, *current_token);
+    return (0);
+}
 
 int double_quotes(t_minishell *minishell, int *i, t_token **current_token)
 {
-	char	*tmp;
-	int		start;
+    char    *tmp;
+    int             start;
 
-	start = ++(*i);
-	while(minishell->input[start] && minishell->input[start] != '\"')
-	{
-		if (minishell->input[start] == '\0')
-		{
-			ft_printf("syntax error: unclosed quote\n");
-			return (1);
-		}
-		start++;
-	}
-	*current_token = ft_calloc(sizeof(t_token), 1);
-	if (!*current_token)
-		return (1);
-	start = *i;
-	while (minishell->input[*i] && minishell->input[*i] != '\"')
-	{
-		if (minishell->input[*i] == '$')
-		{
-			tmp = ft_substr(minishell->input, start, (*i) - start);
-			if (!tmp)
-			{
-				free(*current_token);
-				return (1);
-			}
-			(*current_token)->value = tmp;
-			(*current_token)->type = TOKEN_WORD;
-			add_token_to_list(&minishell->token_list, *current_token);
-			//money_money(minishell, i, current_token);
-		}
-		(*i)++;
-	}
-	tmp = ft_substr(minishell->input, start, ((*i)) - start);
-	if (!tmp)
-	{
-		free(*current_token);
-		return (1);
-	}
-	(*current_token)->value = tmp;
-	(*current_token)->type = TOKEN_WORD;
-	add_token_to_list(&minishell->token_list, *current_token);
-	(*i)++;
-	return (0);
+    start = ++(*i);
+    while (minishell->input[*i] && minishell->input[*i] != '"')
+    {
+        if (minishell->input[*i] == '$')
+        {
+            if (*i - start > 0)
+            {
+                tmp = ft_substr(minishell->input, start, (*i) - start);
+                if (!tmp)
+                    return (1);
+                *current_token = ft_calloc(sizeof(t_token), 1);
+                if (!*current_token)
+                {
+                    free(tmp);
+                    return (1);
+                }
+                (*current_token)->value = tmp;
+                (*current_token)->type = TOKEN_WORD;
+                add_token_to_list(&minishell->token_list, *current_token);
+            }
+            if (money_money(minishell, i, current_token))
+                return (1);
+            start = *i;
+            continue;
+        }
+        (*i)++;
+    }
+    if (minishell->input[*i] != '"')
+    {
+        ft_printf("syntax error: unclosed quote\n");
+        return (1);
+    }
+    tmp = ft_substr(minishell->input, start, (*i) - start);
+    if (!tmp)
+        return (1);
+    *current_token = ft_calloc(sizeof(t_token), 1);
+    if (!*current_token)
+    {
+        free(tmp);
+        return (1);
+    }
+    (*current_token)->value = tmp;
+    (*current_token)->type = TOKEN_WORD;
+    add_token_to_list(&minishell->token_list, *current_token);
+    (*i)++;
+    return (0);
 }
 
-int	single_quotes(t_minishell *minishell, int *i, t_token **current_token)
+int     single_quotes(t_minishell *minishell, int *i, t_token **current_token)
 {
-	char	*tmp;
-	int		start;
+        char    *tmp;
+        int             start;
 
-	start = ++(*i);
-	while (minishell->input[*i] && minishell->input[*i] != '\'')
-		(*i)++;
-	if (minishell->input[*i] == '\0')
-	{
-		ft_printf("syntax error: unclosed quote\n");
-		return (1);
-	}
-	*current_token = ft_calloc(sizeof(t_token), 1);
-	if (!*current_token)
-		return (1);
-	tmp = ft_substr(minishell->input, start, *i - start);
-	if (!tmp)
-	{
-		free(*current_token);
-		return (1);
-	}
-	(*current_token)->value = tmp;
-	(*current_token)->type = TOKEN_WORD;
-	add_token_to_list(&minishell->token_list, *current_token);
-	(*i)++;
-	return (0);
+        start = ++(*i);
+        while (minishell->input[*i] && minishell->input[*i] != '\'')
+                (*i)++;
+        if (minishell->input[*i] == '\0')
+        {
+                ft_printf("syntax error: unclosed quote\n");
+                return (1);
+        }
+        *current_token = ft_calloc(sizeof(t_token), 1);
+        if (!*current_token)
+                return (1);
+        tmp = ft_substr(minishell->input, start, *i - start);
+        if (!tmp)
+        {
+                free(*current_token);
+                return (1);
+        }
+        (*current_token)->value = tmp;
+        (*current_token)->type = TOKEN_WORD;
+        add_token_to_list(&minishell->token_list, *current_token);
+        (*i)++;
+        return (0);
 }

--- a/minikabuk/src/parser/tokenizer.c
+++ b/minikabuk/src/parser/tokenizer.c
@@ -1,30 +1,48 @@
 #include "parser.h"
 
-int	is_that_word(t_minishell *minishell, int *i, t_token **current_token)
+int     is_that_word(t_minishell *minishell, int *i, t_token **current_token)
 {
-    char	*tmp;
-    int		start;
+    char    *tmp;
+    int     start;
 
-    while(minishell->input[*i] && minishell->input[*i] != '|'
-            && minishell->input[*i] != '<' && minishell->input[*i] != '>')
+    while (minishell->input[*i] && minishell->input[*i] != '|' &&
+           minishell->input[*i] != '<' && minishell->input[*i] != '>')
     {
-        while(minishell->input[*i] == ' ' || minishell->input[*i] == '\t')
+        while (minishell->input[*i] == ' ' || minishell->input[*i] == '\t')
             (*i)++;
         start = *i;
-        while(minishell->input[*i] && minishell->input[*i] != ' ' 
-              && minishell->input[*i] != '\t' && minishell->input[*i] != '<'
-              && minishell->input[*i] != '>' && minishell->input[*i] != '|'
-				&& minishell->input[*i] != '\'' && minishell->input[*i] != '\"')
+        while (minishell->input[*i] && minishell->input[*i] != ' ' &&
+               minishell->input[*i] != '\t' && minishell->input[*i] != '<' &&
+               minishell->input[*i] != '>' && minishell->input[*i] != '|' &&
+               minishell->input[*i] != '\'' && minishell->input[*i] != '"')
+        {
+            if (minishell->input[*i] == '$')
+            {
+                if (*i - start > 0)
+                {
+                    *current_token = ft_calloc(sizeof(t_token), 1);
+                    if (!*current_token)
+                        return (0);
+                    tmp = ft_substr(minishell->input, start, *i - start);
+                    (*current_token)->value = tmp;
+                    add_token_to_list(&minishell->token_list, *current_token);
+                }
+                if (money_money(minishell, i, current_token))
+                    return (0);
+                start = *i;
+                continue;
+            }
             (*i)++;
-        *current_token = ft_calloc(sizeof(t_token), 1);
-        if (!*current_token)
-            return (0);
-		//buraya bakkkkkkkkkkkkkkkkkkkk bir alttaki if
-		if (*i - start == 0)
-			break;
-	    tmp = ft_substr(minishell->input, start, *i - start);
-        (*current_token)->value = tmp;
-        add_token_to_list(&minishell->token_list, *current_token);
+        }
+        if (*i - start > 0)
+        {
+            *current_token = ft_calloc(sizeof(t_token), 1);
+            if (!*current_token)
+                return (0);
+            tmp = ft_substr(minishell->input, start, *i - start);
+            (*current_token)->value = tmp;
+            add_token_to_list(&minishell->token_list, *current_token);
+        }
     }
     return (1);
 }

--- a/minikabuk/src/signals/signal.c
+++ b/minikabuk/src/signals/signal.c
@@ -1,4 +1,5 @@
 #include "minishell.h"
+#include <signal.h>
 
 void	ft_ctrl_c(int sig)
 {


### PR DESCRIPTION
## Summary
- handle each substring separately in `double_quotes`
- allocate a new token whenever a piece is added
- implement limited `$` expansion via `money_money`
- expand variables during tokenization
- include missing headers for waiting and signals

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6842ddbebd10832bb19e9af80e34c3f6